### PR TITLE
change dep nearlib to near-api-js, fix ref in main.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     ]
   },
   "dependencies": {
-    "nearlib": "^0.22.0",
+    "near-api-js": "^0.23.0",
     "regenerator-runtime": "^0.13.5"
   }
 }

--- a/src/main.js
+++ b/src/main.js
@@ -1,5 +1,5 @@
 import "regenerator-runtime/runtime";
-import * as nearlib from "nearlib";
+import * as nearAPIJs from "near-api-js";
 import getConfig from "./config";
 
 let nearConfig = getConfig(process.env.NODE_ENV || "development");
@@ -8,10 +8,10 @@ window.nearConfig = nearConfig;
 // Connects to NEAR and provides `near`, `walletAccount` and `contract` objects in `window` scope
 async function connect() {
   // Initializing connection to the NEAR node.
-  window.near = await nearlib.connect(Object.assign(nearConfig, { deps: { keyStore: new nearlib.keyStores.BrowserLocalStorageKeyStore() }}));
+  window.near = await nearAPIJs.connect(Object.assign(nearConfig, { deps: { keyStore: new nearAPIJs.keyStores.BrowserLocalStorageKeyStore() }}));
 
   // Needed to access wallet login
-  window.walletAccount = new nearlib.WalletAccount(window.near);
+  window.walletAccount = new nearAPIJs.WalletAccount(window.near);
 
   // Initializing our contract APIs by contract name and configuration.
   window.contract = await near.loadContract(nearConfig.contractName, {

--- a/src/main.js
+++ b/src/main.js
@@ -1,5 +1,5 @@
 import "regenerator-runtime/runtime";
-import * as nearAPIJs from "near-api-js";
+import * as nearAPI from "near-api-js";
 import getConfig from "./config";
 
 let nearConfig = getConfig(process.env.NODE_ENV || "development");
@@ -8,10 +8,10 @@ window.nearConfig = nearConfig;
 // Connects to NEAR and provides `near`, `walletAccount` and `contract` objects in `window` scope
 async function connect() {
   // Initializing connection to the NEAR node.
-  window.near = await nearAPIJs.connect(Object.assign(nearConfig, { deps: { keyStore: new nearAPIJs.keyStores.BrowserLocalStorageKeyStore() }}));
+  window.near = await nearAPI.connect(Object.assign(nearConfig, { deps: { keyStore: new nearAPI.keyStores.BrowserLocalStorageKeyStore() }}));
 
   // Needed to access wallet login
-  window.walletAccount = new nearAPIJs.WalletAccount(window.near);
+  window.walletAccount = new nearAPI.WalletAccount(window.near);
 
   // Initializing our contract APIs by contract name and configuration.
   window.contract = await near.loadContract(nearConfig.contractName, {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5095,6 +5095,22 @@ ncp@^2.0.0:
   resolved "https://registry.yarnpkg.com/ncp/-/ncp-2.0.0.tgz#195a21d6c46e361d2fb1281ba38b91e9df7bdbb3"
   integrity sha1-GVoh1sRuNh0vsSgbo4uR6d9727M=
 
+near-api-js@^0.23.0:
+  version "0.23.0"
+  resolved "https://registry.yarnpkg.com/near-api-js/-/near-api-js-0.23.0.tgz#422108b33ecfd824e645473997ba00c9f45e0bf2"
+  integrity sha512-rGEgQdjtY9JdwaveDOEauB1voH7eTGM41cJettBO8MKbxPl4obCEiaQAhA80TxJ1I8t3LQhvbI6B8+/EitaeUw==
+  dependencies:
+    "@types/bn.js" "^4.11.5"
+    bn.js "^5.0.0"
+    bs58 "^4.0.0"
+    error-polyfill "^0.1.2"
+    http-errors "^1.7.2"
+    js-sha256 "^0.9.0"
+    mustache "^4.0.0"
+    node-fetch "^2.3.0"
+    text-encoding-utf-8 "^1.0.2"
+    tweetnacl "^1.0.1"
+
 near-bindgen-as@^1.3.1-1:
   version "1.3.1-1"
   resolved "https://registry.yarnpkg.com/near-bindgen-as/-/near-bindgen-as-1.3.1-1.tgz#67572fd531536147d5f4b697a907da1b063c0281"


### PR DESCRIPTION
Small PR using near-api-js
Note: the tests still reference nearlib and it's still in the yarn.lock because near-shell needs to change the test_environment as mentioned here:
nearprotocol/near-shell#312