### PR TITLE
use near-cli instead of near-shell dep

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,22 +27,22 @@ Install dependencies:
 yarn
 ```
 
-Make sure you have `near-shell` by running:
+Make sure you have `near-cli` by running:
 
 ```
 near --version
 ```
 
-If you need to install `near-shell`:
+If you need to install `near-cli`:
 
 ```
-npm install near-shell -g
+npm install near-cli -g
 ```
 
 ## Login
 If you do not have a NEAR account, please create one with [NEAR Wallet](https://wallet.nearprotocol.com).
 
-In the project root, login with `near-shell` by following the instructions after this command:
+In the project root, login with `near-cli` by following the instructions after this command:
 
 ```
 near login

--- a/package.json
+++ b/package.json
@@ -21,12 +21,12 @@
     "jest": "~26.1.0",
     "jest-environment-node": "~26.2.0",
     "near-sdk-as": "^0.4.2",
-    "near-shell": "^0.24.9",
+    "near-cli": "^1.0.1",
     "nodemon": "~2.0.4",
     "parcel-bundler": "~1.12.4"
   },
   "jest": {
-    "testEnvironment": "near-shell/test_environment",
+    "testEnvironment": "near-cli/test_environment",
     "testPathIgnorePatterns": [
       "<rootDir>/assembly/",
       "<rootDir>/node_modules/"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5294,23 +5294,6 @@ ncp@^2.0.0:
   resolved "https://registry.yarnpkg.com/ncp/-/ncp-2.0.0.tgz#195a21d6c46e361d2fb1281ba38b91e9df7bdbb3"
   integrity sha1-GVoh1sRuNh0vsSgbo4uR6d9727M=
 
-near-api-js@^0.27.0:
-  version "0.27.0"
-  resolved "https://registry.yarnpkg.com/near-api-js/-/near-api-js-0.27.0.tgz#d65d4d1059f0d8feb84a56795cb41f5b8c79d68e"
-  integrity sha512-84tNujERdEEj2uboTHd5CbaAQqOWrQfEFGs+2cdVFYWwcFvMgEMQDwXH0tRan0LRRMTlJXGDsKV8LYf37J9K7A==
-  dependencies:
-    "@types/bn.js" "^4.11.5"
-    bn.js "^5.0.0"
-    bs58 "^4.0.0"
-    depd "^2.0.0"
-    error-polyfill "^0.1.2"
-    http-errors "^1.7.2"
-    js-sha256 "^0.9.0"
-    mustache "^4.0.0"
-    node-fetch "^2.3.0"
-    text-encoding-utf-8 "^1.0.2"
-    tweetnacl "^1.0.1"
-
 near-api-js@^0.28.0:
   version "0.28.0"
   resolved "https://registry.yarnpkg.com/near-api-js/-/near-api-js-0.28.0.tgz#2d209b407a4356cd10990792c1e6a7958a51b21c"
@@ -5327,6 +5310,33 @@ near-api-js@^0.28.0:
     node-fetch "^2.3.0"
     text-encoding-utf-8 "^1.0.2"
     tweetnacl "^1.0.1"
+
+near-cli@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/near-cli/-/near-cli-1.0.1.tgz#f261daba930b7c1dec89722c62bb5c2f276926e9"
+  integrity sha512-8+EDJXJRfHh3pzi7vSL9aPO+/Xx+iE3Z1Zuelx54SshuQOLpZMbaTO4HlYRmA2VVOAb5MWDADeMCjgSYPSHQsA==
+  dependencies:
+    ascii-table "0.0.9"
+    bn.js "^5.1.1"
+    bs58 "^4.0.1"
+    chalk "^4.0.0"
+    flagged-respawn "^1.0.1"
+    is-ci "^2.0.0"
+    jest-environment-node "^26.0.0"
+    mixpanel "^0.11.0"
+    ncp "^2.0.0"
+    near-api-js "^0.28.0"
+    open "^7.0.1"
+    rimraf "^3.0.0"
+    stoppable "^1.1.0"
+    tcp-port-used "^1.0.1"
+    update-notifier "^4.0.0"
+    uuid "^8.0.0"
+    v8flags "^3.1.3"
+    yargs "^15.0.1"
+  optionalDependencies:
+    "@ledgerhq/hw-transport-node-hid" "^5.15.0"
+    near-ledger-js "^0.1.1"
 
 near-ledger-js@^0.1.1:
   version "0.1.1"
@@ -5361,33 +5371,6 @@ near-sdk-as@^0.4.2:
     near-vm "^0.0.8"
     semver "^7.1.3"
     visitor-as "^0.1.0"
-
-near-shell@^0.24.9:
-  version "0.24.9"
-  resolved "https://registry.yarnpkg.com/near-shell/-/near-shell-0.24.9.tgz#709180e9cdbcf4f9ab7dfbec51b1dff1007769c9"
-  integrity sha512-z0qCZJNaxoUnFEoYMNUr6TUaaLqNkxhKJciaTIgmMZNHe7IaBOrfDsF2QYuqIEGoPsXs+TN1Z9QRANr1+ffncw==
-  dependencies:
-    ascii-table "0.0.9"
-    bn.js "^5.1.1"
-    bs58 "^4.0.1"
-    chalk "^4.0.0"
-    flagged-respawn "^1.0.1"
-    is-ci "^2.0.0"
-    jest-environment-node "^26.0.0"
-    mixpanel "^0.11.0"
-    ncp "^2.0.0"
-    near-api-js "^0.27.0"
-    open "^7.0.1"
-    rimraf "^3.0.0"
-    stoppable "^1.1.0"
-    tcp-port-used "^1.0.1"
-    update-notifier "^4.0.0"
-    uuid "^8.0.0"
-    v8flags "^3.1.3"
-    yargs "^15.0.1"
-  optionalDependencies:
-    "@ledgerhq/hw-transport-node-hid" "^5.15.0"
-    near-ledger-js "^0.1.1"
 
 near-vm@^0.0.8:
   version "0.0.8"


### PR DESCRIPTION
We're now using
https://www.npmjs.com/package/near-cli
and have a deprecation warning at the top of:
https://www.npmjs.com/package/near-shell

Also the Github has been renamed to:
https://github.com/near/near-cli