### PR TITLE
Add CI tests, pinned version for (old) near-sdk-as, use --frozen-lockfile

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,19 @@
+name: Tests
+on: push
+jobs:
+  tests:
+    strategy:
+      matrix:
+        platform: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '12'
+      - name: Install modules
+        run: yarn install --frozen-lockfile
+      - name: Build and run tests
+        env:
+          IS_GITHUB_ACTION: true
+        run: yarn test

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ git clone https://github.com/near-examples/counter
 Install dependencies:
 
 ```
-yarn
+yarn --frozen-lockfile
 ```
 
 Make sure you have `near-cli` by running:

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "env-cmd": "^10.1.0",
     "jest": "~27.0.6",
     "jest-environment-node": "~27.0.6",
-    "near-sdk-as": "^0.4.2",
+    "near-sdk-as": "0.4.2",
     "near-cli": "^2.0.2",
     "nodemon": "~2.0.9",
     "parcel-bundler": "~1.12.5"

--- a/src/test.js
+++ b/src/test.js
@@ -3,8 +3,6 @@ describe('Token', function () {
   let contract;
   let accountId;
 
-  jasmine.DEFAULT_TIMEOUT_INTERVAL = 10000;
-
   beforeAll(async function () {
     console.log('nearConfig', nearConfig);
     near = await nearlib.connect(nearConfig);

--- a/yarn.lock
+++ b/yarn.lock
@@ -5848,7 +5848,7 @@ near-mock-vm@^0.1.1:
     js-base64 "^2.5.2"
     yargs "^15.3.1"
 
-near-sdk-as@^0.4.2:
+near-sdk-as@0.4.2:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/near-sdk-as/-/near-sdk-as-0.4.2.tgz#20fb9d6b93d852135a18a948a130a68618c50886"
   integrity sha512-pW3m+HmSBfH0OTEApb4G4F2WWFIRlXyw9ULQeiBx3PYd9TuLOUQWw7rQwIqi+NQ/Ic36VrW57kxgYFy+6JMIRA==


### PR DESCRIPTION
Wanting to avoid future problems where dependencies cause problems for folks.

Also instructs users to use `yarn --frozen-lockfile` instead of just regular `yarn`. With these measures, I think we can abate the problems we've seen occur a number of times with AS and the nested dependencies.

